### PR TITLE
Add rate limiting to login, forgot password, and resend OTP actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "@tiptap/react": "^2.5.4",
     "@tiptap/starter-kit": "^2.5.4",
     "@uploadthing/react": "^6.7.2",
+    "@upstash/ratelimit": "^2.0.1",
+    "@upstash/redis": "^1.33.0",
     "arctic": "^1.9.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -2,6 +2,8 @@ import { Metadata } from "next";
 import ForgotPasswordForm from "./ForgotPasswordForm";
 import Image from "next/image";
 import forgotPasswordImage from "@/assets/forgot-password-image.jpg";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 
 export const metadata: Metadata = {
   title: "Forgot Password",
@@ -18,6 +20,11 @@ export default function ForgotPasswordPage() {
           </p>
         </div>
         <ForgotPasswordForm />
+        <Link href="/login">
+          <Button variant="link" className="px-0 mt-2">
+            Back to login
+          </Button>
+        </Link>
       </div>
       <Image
         src={forgotPasswordImage}

--- a/src/app/(auth)/login/LoginForm.tsx
+++ b/src/app/(auth)/login/LoginForm.tsx
@@ -96,7 +96,7 @@ export default function LoginForm() {
         />
         <Link href="forgot-password">
           <Button variant="link" className="px-0 mt-2">
-            Forgot password? Reset here
+            Forgot password?
           </Button>
         </Link>
         <Loading type="submit" className="w-full" isLoading={isPending}>

--- a/src/utils/rateLimit.ts
+++ b/src/utils/rateLimit.ts
@@ -1,0 +1,19 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+
+const redis = Redis.fromEnv();
+
+const rateLimit = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(5, "1 h"),
+})
+
+export const checkRateLimit = async (key: string, limit: number, window: string): Promise<boolean> => {
+  try {
+    const { success } = await rateLimit.limit(key);
+    return success;
+  } catch (error) {
+    console.error("Rate limit check failed:", error);
+    return false;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2181,6 +2181,27 @@
     effect "3.4.5"
     std-env "^3.7.0"
 
+"@upstash/core-analytics@^0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@upstash/core-analytics/-/core-analytics-0.0.10.tgz#e686a313ec2279d5a8d53e6c215085f1c0f5ab4b"
+  integrity sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==
+  dependencies:
+    "@upstash/redis" "^1.28.3"
+
+"@upstash/ratelimit@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@upstash/ratelimit/-/ratelimit-2.0.1.tgz#ff617e31f46755ab71b1a6b68ac8a8f86171d736"
+  integrity sha512-J+0hlkvWUjlVrjcBQhWx7gbaUGsvFF59i+GAx7YQk8L0E0MQ93xzCPu02uaXhGDJGkxiar7nRRPqj3hs+CdAJg==
+  dependencies:
+    "@upstash/core-analytics" "^0.0.10"
+
+"@upstash/redis@^1.28.3", "@upstash/redis@^1.33.0":
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/@upstash/redis/-/redis-1.33.0.tgz#eefe14ea50136f2d14dda78cdc2e788230cd1683"
+  integrity sha512-5WOilc7AE0ITAdE3NCyMwgOq1n3RHcqW0OfmbotiAyfA+QAEe1R7kXin8L/Yladgdc5lkA0GcYyewqKfAw53jQ==
+  dependencies:
+    crypto-js "^4.2.0"
+
 "@virtuoso.dev/react-urx@^0.2.12":
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/@virtuoso.dev/react-urx/-/react-urx-0.2.13.tgz#e2cfc42d259d2a002695e7517d34cb97b64ee9c4"
@@ -2978,6 +2999,11 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+crypto-js@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
+  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
 
 cssesc@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
### Description

This pull request introduces rate limiting to prevent abuse of the login, forgot password, and resend OTP functionalities. We have used Upstash Redis to implement rate limiting with a sliding window algorithm. Each endpoint is limited to 5 requests per hour.

### Changes Made
- **Rate Limiting Configuration:**
  - Configured Upstash Redis with a sliding window rate limiter.
  - Created a `checkRateLimit` function to check the rate limit for different actions.

- **Login Action:**
  - Added a rate limit check for login attempts.
  - Returns an error message if the rate limit is exceeded.

- **Forgot Password Action:**
  - Added a rate limit check for forgot password requests.
  - Returns an error message if the rate limit is exceeded.

- **Resend OTP Action:**
  - Added a rate limit check for OTP resend requests.
  - Returns an error message if the rate limit is exceeded.